### PR TITLE
Fix MCP Dockerfile directory path

### DIFF
--- a/dockerfiles/mcp/Dockerfile
+++ b/dockerfiles/mcp/Dockerfile
@@ -15,10 +15,10 @@ COPY requirements.mcp.txt .
 RUN pip install --no-cache-dir -r requirements.mcp.txt
 
 # Create minimal directory structure
-RUN mkdir -p src/mcp/modules src/server/services src/server/config
+RUN mkdir -p src/mcp_server/modules src/server/services src/server/config
 
 # Copy only MCP-specific files (lightweight protocol wrapper)
-COPY src/mcp/ src/mcp/
+COPY src/mcp_server/ src/mcp_server/
 COPY src/__init__.py src/
 
 # Copy only the minimal server files MCP needs for HTTP communication
@@ -54,4 +54,4 @@ EXPOSE ${ARCHON_MCP_PORT}
 # Health check disabled - use TCP checks in Kubernetes instead
 
 # Run the MCP server using module syntax (avoids naming conflicts)
-CMD ["python", "-m", "src.mcp.mcp_server"]
+CMD ["python", "-m", "src.mcp_server.mcp_server"]


### PR DESCRIPTION
 ## Summary
  - Fixed MCP Dockerfile to use correct upstream directory structure
  - Changed `src/mcp/` to `src/mcp_server/` to match Archon repository
  - Updated CMD to use `src.mcp_server.mcp_server` module path

  ## Problem
  Build was failing with: "failed to compute cache key: failed to calculate checksum of ref... '/src/mcp': not
   found"

  ## Root Cause
  The upstream Archon repository uses `mcp_server` directory name, not `mcp`. Our Dockerfile was referencing
  the wrong path.

  ## Solution
  Updated Dockerfile paths:
  - `COPY src/mcp/ src/mcp/` → `COPY src/mcp_server/ src/mcp_server/`
  - `RUN mkdir -p src/mcp/modules` → `RUN mkdir -p src/mcp_server/modules`
  - `CMD ["python", "-m", "src.mcp.mcp_server"]` → `CMD ["python", "-m", "src.mcp_server.mcp_server"]`

  ## Test plan
  - [x] Verified GitHub Actions build succeeds
  - [x] Confirmed directory structure matches upstream Archon repository